### PR TITLE
feat: intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,33 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+
+    <!-- Favicon -->
+    <link rel="icon" href="/favicon.ico" />
+
+    <!-- Responsive -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+
+    <!-- SEO -->
+    <title>Choose Option</title>
+    <meta
+      name="description"
+      content="A simple decision-making game for groups. Rank your options, let the system find a match — or let fate decide."
+    />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Choose Option" />
+    <meta
+      property="og:description"
+      content="A group decision-making experience where logic meets randomness."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="/preview.png" />
+
+    <!-- Theme -->
+    <meta name="theme-color" content="#050814" />
   </head>
+
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -2,11 +2,12 @@ import "../styles/themes.css";
 interface ButtonProps {
   label: string;
   onClick: () => void;
+  className?: string;
 }
 
-function Button({ label, onClick }: ButtonProps) {
+function Button({ label, onClick, className }: ButtonProps) {
   return (
-    <button className="button" onClick={onClick}>
+    <button className={`button ${className}`} onClick={onClick}>
       {label}
     </button>
   );

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -24,8 +24,12 @@ export function Hero({
         <p>{subtitle}</p>
 
         <div className="hero-actions">
-          <Button label={startLabel} onClick={onStart} />
-          <Button label={instructionsLabel} onClick={onInstructions} />
+          <Button
+            className="button secondary"
+            label={instructionsLabel}
+            onClick={onInstructions}
+          />
+          <Button className="button" label={startLabel} onClick={onStart} />
         </div>
       </div>
     </section>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,35 @@
+import Button from "./Button";
+
+interface HeroProps {
+  title: string;
+  subtitle: string;
+  startLabel: string;
+  instructionsLabel: string;
+  onStart: () => void;
+  onInstructions: () => void;
+}
+
+export function Hero({
+  title,
+  subtitle,
+  startLabel,
+  instructionsLabel,
+  onStart,
+  onInstructions,
+}: HeroProps) {
+  return (
+    <section className="hero">
+      <div className="hero-content">
+        <h1>{title}</h1>
+        <p>{subtitle}</p>
+
+        <div className="hero-actions">
+          <Button label={startLabel} onClick={onStart} />
+          <Button label={instructionsLabel} onClick={onInstructions} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export {};

--- a/src/components/IntroCard.tsx
+++ b/src/components/IntroCard.tsx
@@ -1,0 +1,31 @@
+import Button from "./Button";
+
+interface IntroCardProps {
+  text: string;
+  steps: string[];
+  buttonLabel: string;
+  onStart: () => void;
+}
+
+export function IntroCard({
+  text,
+  steps,
+  buttonLabel,
+  onStart,
+}: IntroCardProps) {
+  return (
+    <div className="card">
+      <div className="content-container">
+        <h2>{text}</h2>
+
+        <div className="fields-container">
+          {steps.map((step, index) => (
+            <p key={index}>{step}</p>
+          ))}
+        </div>
+
+        <Button label={buttonLabel} onClick={onStart} />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -1,15 +1,18 @@
+import { useState } from "react";
 import { useChooseOption } from "../hooks/useChooseOption";
 import { InitialCard } from "../components/InitialCard";
+import { IntroCard } from "../components/IntroCard";
 import { ParticipantCard } from "../components/ParticipantCard";
 import { ResultCard } from "../components/ResultCard";
 import { useTranslation } from "react-i18next";
+import { Hero } from "../components/Hero";
 import "../utils/i18n";
 
 export function Game() {
-  // i18n translations
   const { t } = useTranslation();
+  const [showIntro, setShowIntro] = useState(false);
+  const [showSetup, setShowSetup] = useState(false);
 
-  // ResultCard phrases (array)
   const phrases = t("rCard.fields.text", { returnObjects: true }) as string[];
 
   const {
@@ -27,20 +30,45 @@ export function Game() {
     result,
   } = useChooseOption(phrases);
 
-  // ParticipantCard
   const optionLabel = (index: number) =>
     t("pCard.fields.optionLabel", { number: index + 1 });
 
   const optionPlaceholder = (index: number) =>
     t("pCard.fields.optionPlaceholder", { number: index + 1 });
 
-  // Extract result option
   const option =
-    result?.type === "match" // result from strongMatches - if "match" it will receive an array, if "random" it will receive a string
-      ? (result.data[0]?.option ?? "—") // fallback if undefined
-      : (result?.data ?? "—"); // fallback if null or undefined
+    result?.type === "match"
+      ? (result.data[0]?.option ?? "—")
+      : (result?.data ?? "—");
 
-  if (!gameStarted) {
+  if (!gameStarted && !showIntro && !showSetup) {
+    return (
+      <Hero
+        title={t("hero.fields.title")}
+        subtitle={t("hero.fields.subtitle")}
+        startLabel={t("hero.fields.startButton")}
+        instructionsLabel={t("hero.fields.instructionsButton")}
+        onStart={() => setShowSetup(true)}
+        onInstructions={() => setShowIntro(true)}
+      />
+    );
+  }
+
+  if (!gameStarted && showIntro && !showSetup) {
+    return (
+      <IntroCard
+        text={t("iCard.fields.text")}
+        steps={t("iCard.fields.steps", { returnObjects: true }) as string[]}
+        buttonLabel={t("iCard.fields.button")}
+        onStart={() => {
+          setShowIntro(false);
+          setShowSetup(true);
+        }}
+      />
+    );
+  }
+
+  if (!gameStarted && showSetup) {
     return (
       <InitialCard
         text={t("iCard.fields.text")}
@@ -80,7 +108,7 @@ export function Game() {
     <div>
       <ResultCard
         title={t("rCard.fields.title") || "Match Results"}
-        text={result?.phrase ?? ""} // phrase now comes from hook (stable)
+        text={result?.phrase ?? ""}
         result={option}
         buttonLabel={t("rCard.fields.button")}
         onRestart={resetGame}

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -17,7 +17,6 @@
   --header-bg: rgba(5, 8, 18, 0.72);
 }
 
-/* Card entrance animation */
 @keyframes card-enter {
   from {
     opacity: 0;
@@ -31,7 +30,6 @@
   }
 }
 
-/* Soft floating glow */
 @keyframes card-glow {
   0% {
     box-shadow:
@@ -53,7 +51,6 @@
   }
 }
 
-/* Button shimmer */
 @keyframes button-shimmer {
   0% {
     transform: translateX(-120%);
@@ -113,7 +110,7 @@ body {
 
 .dropdown .selected,
 .dropdown .options li,
-.card .button {
+.button {
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -399,7 +396,7 @@ main {
   cursor: not-allowed;
 }
 
-.card .button {
+.button {
   display: inline-flex;
   justify-content: center;
   align-items: center;
@@ -426,7 +423,7 @@ main {
     0 0 18px rgba(255, 78, 205, 0.18);
 }
 
-.card .button::before {
+.button::before {
   content: "";
   position: absolute;
   top: 0;
@@ -443,7 +440,7 @@ main {
   pointer-events: none;
 }
 
-.card .button:hover {
+.button:hover {
   box-shadow:
     0 12px 28px rgba(139, 92, 246, 0.34),
     0 0 24px rgba(108, 242, 255, 0.18);
@@ -452,15 +449,15 @@ main {
   border-color: rgba(255, 255, 255, 0.18);
 }
 
-.card .button:hover::before {
+.button:hover::before {
   animation: button-shimmer 0.9s ease;
 }
 
-.card .button:active {
+.button:active {
   transform: translateY(0) scale(0.99);
 }
 
-.card .button:focus-visible {
+.button:focus-visible {
   outline: none;
   box-shadow:
     0 0 0 3px rgba(108, 242, 255, 0.14),
@@ -477,6 +474,81 @@ main {
   text-shadow:
     0 0 12px rgba(255, 224, 102, 0.25),
     0 0 24px rgba(108, 242, 255, 0.12);
+}
+
+.hero {
+  position: relative;
+  width: 100%;
+  min-height: 45vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0 24px;
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  width: 520px;
+  height: 520px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    rgba(5, 8, 18, 0.72) 0%,
+    rgba(5, 8, 18, 0.42) 38%,
+    rgba(5, 8, 18, 0) 72%
+  );
+  filter: blur(18px);
+  z-index: 0;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.hero-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.9rem;
+  width: 100%;
+  margin-top: 1rem;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: 2.2rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-shadow:
+    0 0 18px rgba(108, 242, 255, 0.2),
+    0 0 28px rgba(139, 92, 246, 0.14);
+}
+
+.hero p {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.5;
+  color: var(--text-soft);
+}
+
+.button.secondary {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  color: var(--text-soft);
+  box-shadow: none;
+}
+
+.button.secondary:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(108, 242, 255, 0.2);
+  color: var(--font-color);
 }
 
 @media (max-width: 480px) {
@@ -516,7 +588,7 @@ main {
     font-size: 0.95rem;
   }
 
-  .card .button {
+  .button {
     width: 100%;
     padding: 0.8rem 1rem;
     font-size: 1rem;
@@ -529,6 +601,14 @@ main {
 
   .card p {
     font-size: 0.95rem;
+  }
+
+  .hero h1 {
+    font-size: 1.8rem;
+  }
+
+  .hero p {
+    font-size: 1rem;
   }
 
   .result-highlight,

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -12,7 +12,7 @@ const resources = {
         fields: {
           title: "Welcome to Choose Option.",
           subtitle:
-            "It’s not really a game. It’s just humans asking the stars what to do when they can’t decide on their own.",
+            "It's not really a game. It's just humans asking the stars what to do when they can't decide on their own.",
           startButton: "Start",
           instructionsButton: "Instructions",
         },
@@ -47,7 +47,7 @@ const resources = {
             "We consulted the mystical forces, and they whispered (loudly):",
             "You asked for help… and you got it. The final decision is:",
             "We spun the cosmic wheel. It landed on:",
-            "The universe played ‘eeny, meeny, miny, moe’ and said:",
+            "The universe played 'eeny, meeny, miny, moe' and said:",
             "The oracle of randomness answered without a second thought:",
             "We ran highly complex calculations (and guessed a little). The result is:",
             "We let luck decide… and it was in a good mood. The answer is:",
@@ -99,7 +99,7 @@ const resources = {
             "Consultamos as forças místicas, e elas sussurraram (bem alto):",
             "Você pediu ajuda… e recebeu. A decisão final é:",
             "Rodamos a roleta cósmica. Caiu em:",
-            "O universo fez ‘eeny, meeny, miny, moe’ e disse:",
+            "O universo fez 'eeny, meeny, miny, moe’ e disse:",
             "O oráculo do acaso respondeu sem pensar duas vezes:",
             "Fizemos cálculos altamente complexos (e chutamos um pouco). O resultado é:",
             "Deixamos a sorte decidir… e ela estava de bom humor. A resposta é:",

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -8,10 +8,24 @@ import LanguageDetector from "i18next-browser-languagedetector";
 const resources = {
   en: {
     translation: {
+      hero: {
+        fields: {
+          title: "Welcome to Choose Option.",
+          subtitle:
+            "It’s not really a game. It’s just humans asking the stars what to do when they can’t decide on their own.",
+          startButton: "Start",
+          instructionsButton: "Instructions",
+        },
+      },
       iCard: {
         fields: {
           text: "Choose the number of participants",
           button: "Start",
+          steps: [
+            "Choose the number of participants",
+            "Each participant ranks their options by priority",
+            "The app picks a result based on a match, or randomly if no match is found",
+          ],
         },
       },
       pCard: {
@@ -46,10 +60,24 @@ const resources = {
   },
   pt: {
     translation: {
+      hero: {
+        fields: {
+          title: "Bem-vindo ao Choose Option.",
+          subtitle:
+            "Não é exatamente um jogo. São só pessoas pedindo ajuda às estrelas quando não conseguem decidir sozinhas.",
+          startButton: "Começar",
+          instructionsButton: "Instruções",
+        },
+      },
       iCard: {
         fields: {
           text: "Escolha a quantidade de participantes",
           button: "Iniciar",
+          steps: [
+            "Escolha a quantidade de participantes",
+            "Cada participante organiza suas opções por ordem de prioridade",
+            "O app escolhe um resultado com base em match, ou aleatoriamente caso não encontre um match",
+          ],
         },
       },
       pCard: {


### PR DESCRIPTION
# Description

Introduce a new onboarding flow with a Hero entry point, separating explanation, instructions, and game setup.

Previously, the app started directly with the setup (InitialCard), which could be confusing for first-time users. This PR restructures the flow to make the experience more intentional:

- Hero is now the landing view with app context
- Users can either start immediately or view instructions
- Instructions are displayed in a dedicated IntroCard
- Setup (InitialCard) is shown only after user intent

Additional improvements:
- Unified button styles across the app
- Added secondary button style for "Instructions"
- Improved Hero readability without using a full-width overlay

# Type of change

- [x] feat: New feature
- [ ] bug: Bug fix
- [x] chore: Maintenance task
- [ ] documentation: Documentation update
- [x] style: Styling changes (CSS, layout, etc.)
- [ ] test: Adding or fixing tests
- [x] refactor: Code refactoring (no behavior change)

# Checklist

- [x] Code reviewed and cleaned (no commented or unused code)
- [x] Code has been manually tested
- [x] Commits are clear and properly named

# Related issues

Closes #3 